### PR TITLE
add `bin` option like `bin` in package.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,15 @@
 const path = require('path');
+const fs = require('fs');
 const child_process = require('child_process');
 
 module.exports = (opts = {}) => {
 	let input;
 	let proc;
+	let bin, dest;
 
+	if (typeof opts.bin !== "string" && opts.bin) {
+		throw new Error(`option 'bin' in rollup-plugin-run must be 'string', not '${typeof opts.bin}'`)
+	} else bin = opts.bin;
 	const args = opts.args || [];
 	const forkOptions = opts.options || opts;
 	delete forkOptions.args;
@@ -23,7 +28,7 @@ module.exports = (opts = {}) => {
 				inputs = Object.values(inputs);
 			}
 
-			if (inputs.length > 1) {
+			if (inputs.length > 1 && !bin) {
 				throw new Error(`rollup-plugin-run only works with a single entry point`);
 			}
 
@@ -37,9 +42,8 @@ module.exports = (opts = {}) => {
 
 			const dir = outputOptions.dir || path.dirname(outputOptions.file);
 
-			let dest;
-
-			for (const fileName in bundle) {
+			if (bin) dest = bin;
+			else for (const fileName in bundle) {
 				const chunk = bundle[fileName];
 
 				if (!('isEntry' in chunk)) {


### PR DESCRIPTION
> [Motivation]: Hi, I bump into an edge case and happen to tinker this plugin a bit to suit my need 🙂

By doing this, it allows supporting multiple configurations (and probably multiple entries) by specifying which file is to execute.
For example:
```js
export default {
		input: glob([
			"src/commands/*.js",
			"src/index.js"
		]),
		output: {
			dir: "dist",
			format: "cjs" // seems this 🖣 plugin only support cjs 🤔
		},
		plugins: [run({ bin: "dist/index.js" })]
		experimentalCodeSplitting: true
}
```

<details>
<summary>However, I can't find a way to avoid running it twice when using multiple configuration</summary>

```js
const dev = process.env.ROLLUP_WATCH === 'true'
const configure = ({input, output, ...others}) => ({
	input,
	output,
	...others,
	plugins: [
		...otherPlugins,
		dev && run({ bin: "dist/index.js" })
	]
})

// I'm trying to bundle cli with multi command project (using oclif)
export default [
	configure({
		input: glob("src/commands/*.ts"),
		output: {
			dir: "dist",
			format: "cjs"
		},
		experimentalCodeSplitting: true
	}),
	configure({ // main script and also exported class/lib
		input: "src/index.ts",
		output: {
			file: "dist/index.js",
			format: "cjs",
			exports: "named"
		}
	})
]
```
This will result:
1. always execute `dist/index.js` 2 times when `rollup -c --watch`
2. execute `dist/index.js` 1 times when 1 file change, either in `src/commands/*.ts` or `src/index.ts`
3. execute `dist/index.js` 2 times when multiple file hit _save_ at the same time (I found this when clicking **save all** in vscode)

Also, this doesn't work
```diff
export default [
	configure({
		input: glob("src/commands/*.ts"),
		output: {
			dir: "dist",
			format: "cjs"
		},
		experimentalCodeSplitting: true
	}),
	configure({ // main script and also exported class/lib
		input: "src/index.ts",
		output: {
			file: "dist/index.js",
			format: "cjs",
			exports: "named"
		},
+		watch: {
+			include: "src/**"
+		}
	})
]
```
</details>